### PR TITLE
Fix bug in Summary tab for negative yield values

### DIFF
--- a/src/components/Practices/index.jsx
+++ b/src/components/Practices/index.jsx
@@ -376,8 +376,13 @@ const Practices = () => {
       5: 'fifth',
     }[Yield.q4];
 
-    details.Yield = {
+    details.Yield = Yield.total >= 0 ? {
       [`Improved yield estimate in ${year} year of cover crops`]: dollars(Yield.total),
+    } : {
+      'Decreased yield estimate': Yield.total.toLocaleString('en-US', {
+        style: 'currency',
+        currency: 'USD',
+      }),
     };
   }
   return (


### PR DESCRIPTION
This PR fixes the below mentioned bug in issue https://github.com/precision-sustainable-ag/dst-econ/issues/160

Bug: When a negative value was entered in the Yield tab, Summary tab would break

RCA: dollar() method used in Summary tab was returning the dollar value for positive yield values but was returning a jsx element (with red color font style) for negative values.

Fix: Added custom USD formatting for Yield values and updated the Yield text to 'Decreased yield estimate' in case of negative values. Below is a sample:
![image](https://github.com/precision-sustainable-ag/dst-econ/assets/51780939/bf7755c6-8fdb-429b-a97b-ad3ff58f4874)
