### PR TITLE
Update replace functions with optional chaining to avoid app crashes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -164,7 +164,7 @@ const Navigation = ({ current }) => {
             <Button variant="contained" color="primary" className="mobileNext">
               <div>
                 NEXT: &nbsp;
-                {next.replace('Practices', 'Summary')}
+                {next?.replace('Practices', 'Summary')}
               </div>
             </Button>
           </NavLink>
@@ -182,7 +182,7 @@ const Navigation = ({ current }) => {
       >
         <div id="Navigation" className="desktop" style={{ marginLeft: 'auto' }}>
           {back && (
-          <NavLink to={`/${back.replace('Home', '')}`}>
+          <NavLink to={`/${back?.replace('Home', '')}`}>
             <Button variant="contained" color="primary" tabIndex={-1}>
               {!mobile ? (
                 <div>
@@ -299,7 +299,7 @@ const unneededCSS = () => {
 
             rule.style.removeProperty(property);
             const newValue = getComputedStyle(obj)[property];
-            rule.style.setProperty(property, value.replace(' !important', ''), important ? 'important' : '');
+            rule.style.setProperty(property, value?.replace(' !important', ''), important ? 'important' : '');
 
             if (originalValue === newValue) {
               console.log(rule.selectorText, '-', property, '-', value, '-', originalValue, '-', newValue);
@@ -332,7 +332,7 @@ const unusedCSS = (log = false) => {
             }
 
             const re = /::[-\w]+/g;
-            const els = document.querySelectorAll(selector.replace(re, '') || 'EMPTY');
+            const els = document.querySelectorAll(selector?.replace(re, '') || 'EMPTY');
             if (!selectors[selector] && !els.length) {
               unused.push(selector);
             } else {
@@ -349,7 +349,7 @@ const unusedCSS = (log = false) => {
   if (log) {
     console.log('_'.repeat(20));
     unused
-      .sort((a, b) => a.replace(/^#/, 'ZZZ').localeCompare(b.replace(/^#/, 'ZZZ')))
+      .sort((a, b) => a?.replace(/^#/, 'ZZZ').localeCompare(b?.replace(/^#/, 'ZZZ')))
       .forEach((s) => console.log(s));
   }
 };

--- a/src/components/Activity/index.jsx
+++ b/src/components/Activity/index.jsx
@@ -9,7 +9,7 @@ import './styles.scss';
 const Costs = ({ desc, type }) => {
   const selector = goto(get, type);
   const state = useSelector(selector);
-  const d = desc.replace('Storage shed', 'Storage');
+  const d = desc?.replace('Storage shed', 'Storage');
 
   const val = state[d];
 

--- a/src/components/Logic/index.jsx
+++ b/src/components/Logic/index.jsx
@@ -79,7 +79,7 @@ const Logic = ({
       ? 'No reduced application activity'
       : 'No additional application activity',
     ...Object.keys(db.costDefaults),
-  ].includes(currentImplement.replace(/hire (?!custom operator)/i, ''));
+  ].includes(currentImplement?.replace(/hire (?!custom operator)/i, ''));
 
   iscustom = currentImplement === 'Incorporate planting with fertilizing. No CC planting cost.' ? true : iscustom;
 

--- a/src/store/redux-autosetters.jsx
+++ b/src/store/redux-autosetters.jsx
@@ -65,7 +65,7 @@ export const createStore = (initialState, { afterChange = {}, reducers = {} }) =
           const func = obj[key].toString();
 
           Object.keys(allkeys).forEach((key2) => {
-            const regex = new RegExp(`${key2.replace(/[.$]/g, (c) => `\\${c}`)}`);
+            const regex = new RegExp(`${key2?.replace(/[.$]/g, (c) => `\\${c}`)}`);
             if (func.match(regex)) {
               methods[key2] = methods[key2] || {};
               methods[key2][fullkey] = funcs[fullkey];
@@ -102,7 +102,7 @@ export const createStore = (initialState, { afterChange = {}, reducers = {} }) =
             if (afterChange[fullkey]) {
               const func = afterChange[fullkey].toString();
               Object.keys(allkeys).forEach((key2) => {
-                if (func.match(new RegExp(`${key2.replace(/[.$]/g, (c) => `\\${c}`)}`))) {
+                if (func.match(new RegExp(`${key2?.replace(/[.$]/g, (c) => `\\${c}`)}`))) {
                   processMethods(state, key2);
                 }
               });


### PR DESCRIPTION
This PR includes the fix for this issue: https://github.com/precision-sustainable-ag/dst-feedback/issues/55

.replace has been replaced with ?.replace (optional chaining). This was done to ensure that the error "Uncaught TypeError: Cannot read properties of null (reading 'replace')" does not crash the application again.