### PR TITLE
Hotfix/review feb19

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -42,6 +42,7 @@ import Airtable from './components/Airtables';
 import Feedback from './components/Feedback';
 import AT from './components/AT';
 import { Summary } from './components/Activity';
+import Snapshot from './components/Snapshot';
 
 let firstTime = true;
 
@@ -138,6 +139,7 @@ const paths = {
   Revenue,
   Resources,
   Feedback,
+  Snapshot,
 };
 
 if (dev) {
@@ -593,7 +595,7 @@ const App = () => {
 
         <div className="menu-items topmenu" ref={topMenu}>
 
-          {keys.filter((path) => !(/Practices|Revenue|Resources|AT|Feedback/.test(path))).map((path) => {
+          {keys.filter((path) => !(/Practices|Revenue|Resources|AT|Feedback|Snapshot/.test(path))).map((path) => {
             let cname = path === screen ? 'selected' : '';
             const dis = disabled && !/Home|Field/.test(path);
 
@@ -626,8 +628,9 @@ const App = () => {
         <hr className="horizontalline" />
 
         <div className="menu-items">
-          {keys.filter((path) => (/Practices|Revenue|Resources|AT|Feedback/.test(path))).map((path) => {
+          {keys.filter((path) => (/Practices|Revenue|Resources|AT|Feedback|Snapshot/.test(path))).map((path) => {
             if (mobile && path === 'AT') return null;
+            if (!mobile && path === 'Snapshot') return null;
 
             let cname = path === screen ? 'selected summary' : 'summary';
             const dis = path !== 'Resources' && disabled && !/Feedback|AT/.test(path);
@@ -707,6 +710,7 @@ const App = () => {
           <Route key="Resources" path="Resources" element={<Resources />} />
           <Route key="Feedback" path="Feedback" element={<Feedback />} />
           <Route key="AT" path="AT" element={<AT />} />
+          <Route key="Snapshot" path="Snapshot" element={<Snapshot />} />
           {Object.keys(airTables).map((key) => (
             <Route key={key} path={key} element={<Airtable name={key} url={airTables[key]} />} />
           ))}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -630,7 +630,6 @@ const App = () => {
         <div className="menu-items">
           {keys.filter((path) => (/Practices|Revenue|Resources|AT|Feedback|Snapshot/.test(path))).map((path) => {
             if (mobile && path === 'AT') return null;
-            if (!mobile && path === 'Snapshot') return null;
 
             let cname = path === screen ? 'selected summary' : 'summary';
             const dis = path !== 'Resources' && disabled && !/Feedback|AT/.test(path);
@@ -647,7 +646,7 @@ const App = () => {
                 accessKey={accessKey}
                 tabIndex={-1}
                 onFocus={(e) => e.target.blur()}
-                className={`${cname} ${path}`}
+                className={`${cname} ${path}${path === 'Snapshot' ? ' budgetTable' : ''}`}
               >
                 <Button
                   screen={path}

--- a/src/App.scss
+++ b/src/App.scss
@@ -76,6 +76,11 @@ body {
   }
 }
 
+a.budgetTable {
+	float: right;
+	margin-right: 1%;
+}
+
 nav {
   color: #eee;
   padding: 0.5rem;

--- a/src/App.scss
+++ b/src/App.scss
@@ -68,6 +68,7 @@ body {
 @media screen and (min-width: 1250px) {
   .desktop2 {display: initial;}
   .test-buttons {display: flex;}
+	.budgetTable {display: none;}
 
   #Container {
     max-width: 1000px;

--- a/src/components/Activity/index.jsx
+++ b/src/components/Activity/index.jsx
@@ -259,7 +259,7 @@ const CostsBenefits = ({ type }) => {
   return null;
 }; // CostsBenefits
 
-export const Summary = () => {
+export const SummaryDetails = ({ view }) => {
   const coverCropTotal = useSelector(get.coverCropTotal) || 0;
   const seedbedTotal = useSelector(get.seedbed).total || 0;
   const plantingTotal = useSelector(get.planting).total || 0;
@@ -281,84 +281,120 @@ export const Summary = () => {
   const cashCrop = useSelector(get.cashCrop);
 
   const style = total > 0 ? { color: 'red' } : { color: 'black' };
-  // const classes = useStyles();
 
   const componentRef = createRef();
-  // const handlePrint = useReactToPrint({
-  //   content: () => componentRef.current,
-  // });
 
   return (
     (total || farm || field || acres || cashCrop) && (
-      <div className="desktop2">
-        <Draggable handle="strong">
-          <Card id="Summary" variant="outlined" style={{ backgroundColor: '#eee' }} ref={componentRef}>
-            <CardContent>
-              <div ref={componentRef}>
-                <strong className="cursor">
-                  Summary
-                </strong>
+    <Draggable handle="strong" disabled={view !== 'DESKTOP'}>
+      <Card
+        id="Summary"
+        variant="outlined"
+        style={{
+          backgroundColor: '#eee',
+          position: view === 'DESKTOP' ? 'absolute' : '',
+          marginTop: view === 'DESKTOP' ? '' : '5%',
+          margin: view === 'DESKTOP' ? '' : 'auto',
+        }}
+        ref={view === 'DESKTOP' ? componentRef : null}
+      >
+        <CardContent>
+          <div ref={view === 'DESKTOP' ? componentRef : null}>
+            <strong className="cursor" style={{ cursor: view === 'DESKTOP' ? '' : 'auto' }}>
+              Snapshot
+            </strong>
 
-                <table>
-                  {(farm || field || acres || cashCrop) && (
-                  <>
-                    <thead />
-                    <tbody>
-                      {farm && (
-                      <tr>
-                        <td>Farm     </td>
-                        <td style={{ textAlign: 'left' }}>
-                          {farm}
-                        </td>
-                      </tr>
-                      )}
-                      {field && (
-                      <tr>
-                        <td>Field    </td>
-                        <td style={{ textAlign: 'left' }}>
-                          {field}
-                        </td>
-                      </tr>
-                      )}
-                      {acres && (
-                      <tr>
-                        <td>Acres    </td>
-                        <td style={{ textAlign: 'left' }}>
-                          {acres}
-                        </td>
-                      </tr>
-                      )}
-                      {cashCrop && (
-                      <tr>
-                        <td>Cash crop</td>
-                        <td style={{ textAlign: 'left' }}>
-                          {cashCrop}
-                        </td>
-                      </tr>
-                      )}
-                    </tbody>
-                  </>
+            <table>
+              {(farm || field || acres || cashCrop) && (
+              <>
+                <thead />
+                <tbody>
+                  {farm && (
+                  <tr>
+                    <td>Farm     </td>
+                    <td style={{ textAlign: 'left' }}>
+                      {farm}
+                    </td>
+                  </tr>
                   )}
-                  <CostsBenefits type="Costs" />
-                  <CostsBenefits type="Benefits" />
-                  {total ? (
-                    <tfoot>
-                      <tr style={{ fontWeight: 'bold' }}>
-                        <td>
-                          Total Economic
-                          {' '}
-                          {total < 0 ? 'Benefit' : 'Cost'}
-                        </td>
-                        <td style={style}>{dollars(Math.abs(total))}</td>
-                      </tr>
-                    </tfoot>
-                  ) : null}
-                </table>
-              </div>
-            </CardContent>
-          </Card>
-        </Draggable>
-      </div>
+                  {field && (
+                  <tr>
+                    <td>Field    </td>
+                    <td style={{ textAlign: 'left' }}>
+                      {field}
+                    </td>
+                  </tr>
+                  )}
+                  {acres && (
+                  <tr>
+                    <td>Acres    </td>
+                    <td style={{ textAlign: 'left' }}>
+                      {acres}
+                    </td>
+                  </tr>
+                  )}
+                  {cashCrop && (
+                  <tr>
+                    <td>Cash crop</td>
+                    <td style={{ textAlign: 'left' }}>
+                      {cashCrop}
+                    </td>
+                  </tr>
+                  )}
+                </tbody>
+              </>
+              )}
+              <CostsBenefits type="Costs" />
+              <CostsBenefits type="Benefits" />
+              {total ? (
+                <tfoot>
+                  <tr style={{ fontWeight: 'bold' }}>
+                    <td>
+                      Total Economic
+                      {' '}
+                      {total < 0 ? 'Benefit' : 'Cost'}
+                    </td>
+                    <td style={style}>{dollars(Math.abs(total))}</td>
+                  </tr>
+                </tfoot>
+              ) : null}
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+    </Draggable>
+    )
+  );
+};
+
+export const Summary = () => {
+  const coverCropTotal = useSelector(get.coverCropTotal) || 0;
+  const seedbedTotal = useSelector(get.seedbed).total || 0;
+  const plantingTotal = useSelector(get.planting).total || 0;
+  const grazingTotal = useSelector(get.grazing).total || 0;
+  const terminationTotal = useSelector(get.termination).total || 0;
+  const tillageTotal = useSelector(get.tillage).total || 0;
+  const fertilityTotal = -useSelector(get.fertility).total || 0;
+  const erosionTotal = -useSelector(get.erosion).total || 0;
+  const yieldTotal = -useSelector(get.yield).total || 0;
+  const herbicideTotal = useSelector(get.herbicide).total || 0;
+  const additionalTotal = -useSelector(get.additional).total || 0;
+
+  const total = +coverCropTotal + +seedbedTotal + +plantingTotal + +grazingTotal + +fertilityTotal + +erosionTotal
+                + +terminationTotal + +tillageTotal + +yieldTotal + +herbicideTotal + +additionalTotal;
+
+  const farm = useSelector(get.farm);
+  const field = useSelector(get.field);
+  const acres = useSelector(get.mapFeatures.area);
+  const cashCrop = useSelector(get.cashCrop);
+
+  return (
+    (total || farm || field || acres || cashCrop) && (
+    <div className="desktop2">
+      <Draggable handle="strong">
+        <SummaryDetails view="DESKTOP" />
+      </Draggable>
+    </div>
     )
   );
 }; // Summary

--- a/src/components/Activity/index.jsx
+++ b/src/components/Activity/index.jsx
@@ -301,7 +301,7 @@ export const SummaryDetails = ({ view }) => {
         <CardContent>
           <div ref={view === 'DESKTOP' ? componentRef : null}>
             <strong className="cursor" style={{ cursor: view === 'DESKTOP' ? '' : 'auto' }}>
-              Snapshot
+              Budget Table
             </strong>
 
             <table>

--- a/src/components/Activity/styles.scss
+++ b/src/components/Activity/styles.scss
@@ -1,5 +1,5 @@
 #Summary {
-  position: absolute;
+  // position: absolute;
   font-size: 0.8rem;
   width: 240px;
   left: 100%;

--- a/src/components/Snapshot/index.jsx
+++ b/src/components/Snapshot/index.jsx
@@ -1,18 +1,17 @@
 import React from 'react';
 import { SummaryDetails } from '../Activity';
 
-const Snapshot = () => {
-  console.log('snapshot');
-  return (
-    <SummaryDetails view="MOBILE" />
-  );
-};
+const Snapshot = () => (
+  <SummaryDetails view="MOBILE" />
+);
 
 Snapshot.menu = (
   <span>
-    Sna
-    <u>p</u>
-    shot
+    B
+    <u>u</u>
+    dget
+    {' '}
+    Table
   </span>
 );
 

--- a/src/components/Snapshot/index.jsx
+++ b/src/components/Snapshot/index.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { SummaryDetails } from '../Activity';
+
+const Snapshot = () => {
+  console.log('snapshot');
+  return (
+    <SummaryDetails view="MOBILE" />
+  );
+};
+
+Snapshot.menu = (
+  <span>
+    Sna
+    <u>p</u>
+    shot
+  </span>
+);
+
+export default Snapshot;

--- a/src/store/Store.jsx
+++ b/src/store/Store.jsx
@@ -253,6 +253,7 @@ const initialState = {
         ? 'Use cover crop adjusted yield estimates from the table above'
         : 'Enter my own estimated yield change'
     ),
+    q4: '1',
     price: (state) => db.commodities?.[state.cashCrop]?.price,
     typical: (state) => state.yield.yield * state.yield.price,
     adjusted: (state) => {
@@ -1285,14 +1286,14 @@ export const exampleYield1 = () => {
   store.dispatch(set.yield.yield('150'));
   store.dispatch(set.cashCrop('Soybeans'));
   store.dispatch(set.yield.q2('Use cover crop adjusted yield estimates from the table above'));
-  store.dispatch(set.yield.q4('5'));
+  store.dispatch(set.yield.q4('1'));
 }; // exampleYield1
 
 export const exampleYield2 = () => {
   store.dispatch(set.yield.yield('150'));
   store.dispatch(set.cashCrop('Corn'));
   store.dispatch(set.yield.q2('Use cover crop adjusted yield estimates from the table above'));
-  store.dispatch(set.yield.q4('5'));
+  store.dispatch(set.yield.q4('1'));
 }; // exampleYield2
 
 export const exampleAdditional = () => {


### PR DESCRIPTION
This PR fixes issues mentioned in https://github.com/precision-sustainable-ag/dst-econ/issues/191

Issue 1: Summary table
Fix: 
1. Changed the word "Summary" to "Snapshot."  That way, it won't be confused with the Summary tab.
2. On mobile, put a Snapshot button on the far right of the second row of buttons.
3. When the button is clicked, snapshot table is displayed.

Issue 2: Yield tab
Fix:
1. Defaulted the selection to 1 year